### PR TITLE
Fix minio-go tests as per the latest changes in minio-go library.

### DIFF
--- a/run/core/minio-go/minio-go-tests.go
+++ b/run/core/minio-go/minio-go-tests.go
@@ -1546,7 +1546,7 @@ func testCopyObject() {
 	src := minio.NewSourceInfo(bucketName, objectName, nil)
 
 	// All invalid conditions first.
-	 err = src.SetModifiedSinceCond(time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC))
+	err = src.SetModifiedSinceCond(time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC))
 	if err == nil {
 		log.Fatal("Error:", err)
 	}
@@ -1573,9 +1573,9 @@ func testCopyObject() {
 	}
 
 	dst, err := minio.NewDestinationInfo(bucketName+"-copy", objectName+"-copy", nil, nil)
-	 if err != nil {
-		 log.Fatal(err)
-	 }
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	// Perform the Copy
 	err = c.CopyObject(dst, src)
@@ -1609,7 +1609,7 @@ func testCopyObject() {
 
 	// CopyObject again but with wrong conditions
 	src = minio.NewSourceInfo(bucketName, objectName, nil)
- 	err = src.SetUnmodifiedSinceCond(time.Date(2014, time.April, 0, 0, 0, 0, 0, time.UTC))
+	err = src.SetUnmodifiedSinceCond(time.Date(2014, time.April, 0, 0, 0, 0, 0, time.UTC))
 	if err != nil {
 		log.Fatal("Error:", err)
 	}
@@ -2422,7 +2422,7 @@ func logTrace() {
 
 func testComposeObjectErrorCases() {
 
-		// Instantiate new minio client object.
+	// Instantiate new minio client object.
 	c, err := minio.NewV4(
 		os.Getenv("SERVER_ENDPOINT"),
 		os.Getenv("ACCESS_KEY"),


### PR DESCRIPTION
Minio-go introduced new api and changed copy objects api (https://github.com/minio/minio-go/commit/129fe893b2ac95d322d531b7029981f71c351e53).

This broke mint tests. The PR updates mint minio-go tests as per minio-go SDK. 

Note:
Once https://github.com/minio/minio-go/pull/727 is merged. Mint will be updated to pull tests from minio-go SDK and we'll not maintain multiple copies of the minio-go SDK tests. 