### PR TITLE
Improved logging and tests for mc

### DIFF
--- a/run/core/mc/run.sh
+++ b/run/core/mc/run.sh
@@ -26,9 +26,9 @@ setupMCTarget() {
 
     target_address=$scheme://$SERVER_ENDPOINT
     
-    echo "Adding mc host alias target $target_address"
+    # echo "Adding mc host alias target $target_address"
 
-    ./mc config host add target "$target_address" "$ACCESS_KEY" "$SECRET_KEY"
+    ./mc config host add target "$target_address" "$ACCESS_KEY" "$SECRET_KEY" > /dev/null
 }
 
 main() {
@@ -43,9 +43,9 @@ main() {
     setupMCTarget >>"$logfile"  2>&1 || { echo 'mc setup failed' ; exit 1; }
 
     run 2>>"$errfile" 1>>"$logfile" || { echo 'mc run failed.'; rc=1; } 
-    grep -e '<ERROR>' "$logfile" >> "$errfile"
     return $rc
 }
 
 # invoke the script
 main "$@"
+


### PR DESCRIPTION
Prior to the changes mc printed every step to output.log, and logged the tests 
which were intended to throw errors under error.log. 

mc output.log will now provide colorized print of all tests which are executed, 
all progress bars and extraneous prints have been removed to make output.log 
more readable. mc error.log will only hold errors if an unintentional error is 
thrown, the convention followed for logging is that the test which failed will 
be printed to both output and error.log, inside of error.log a line number which 
the test failed on will also be provided. Because these tests are being done 
on mc error logging can be improved with the --debug flag. For mc share 
upload, and mc share download (the more complicated commands), --debug 
stack traces are logged under error.log if an error is found. 

In accordance with the doc tests for watch (experimental), cat, and ls have 
all been added to mc.

Fixes #86 