### PR TITLE
Create test directory for minio-js tests 

### DIFF
--- a/build/js/minio-js.sh
+++ b/build/js/minio-js.sh
@@ -25,7 +25,8 @@ _init() {
 # Compile test files
 install() {
     #TODO - Change this to release based URL once we make a minio-js release
-    curl https://raw.githubusercontent.com/minio/minio-js/master/src/test/functional/functional-tests.js > "${MINIO_JS_SDK_PATH}"/functional-tests.js
+    mkdir "${MINIO_JS_SDK_PATH}"/test
+    curl https://raw.githubusercontent.com/minio/minio-js/master/src/test/functional/functional-tests.js > "${MINIO_JS_SDK_PATH}"/test/functional-tests.js
     npm --prefix "$MINIO_JS_SDK_PATH" install --save "minio@$MINIO_JS_SDK_VERSION"
     npm --prefix "$MINIO_JS_SDK_PATH" install
 }


### PR DESCRIPTION
Currently `test` directory is not created in `run/core/minio-js` causing `npm test` to fail and not run minio-js functional tests. 

This PR fixes the problem.