### PR TITLE
Add support for JSON logging format in minio-js

### DIFF
--- a/build/minio-js/install.sh
+++ b/build/minio-js/install.sh
@@ -15,7 +15,7 @@
 #  limitations under the License.
 #
 
-MINIO_JS_VERSION="3.2.0"
+MINIO_JS_VERSION="3.2.1"
 
 test_run_dir="$MINT_RUN_CORE_DIR/minio-js"
 mkdir "${test_run_dir}/test"

--- a/run/core/minio-js/minioreporter.js
+++ b/run/core/minio-js/minioreporter.js
@@ -1,0 +1,54 @@
+/*
+ * Minio Reporter for JSON formatted logging, (C) 2017 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var mocha = require('mocha');
+module.exports = minioreporter;
+
+function minioreporter(runner) {
+  mocha.reporters.Base.call(this, runner);
+   var self = this;
+
+  runner.on('pass', function (test) {
+    var res = test.title.split("_");
+    process.stdout.write(JSON.stringify({name: "minio-js", status: "PASS", function: res[0], args: res[1], alert: res[2], duration: test.duration}));
+  });
+
+  runner.on('fail', function (test) {
+     test.err = errorJSON (test.error)
+     var res = test.title.split("_");
+    process.stdout.write(JSON.stringify({name: "minio-js", status: "FAIL", function: res[0], args: res[1], alert: res[2], duration: test.duration, error: test.err}));
+  });
+
+}
+
+
+/**
+ * Transform `error` into a JSON object.
+ *
+ * @api private
+ * @param {Error} err
+ * @return {Object}
+ */
+function errorJSON (err) {
+
+  if (err == null )
+ return "";
+  var res = {};
+  Object.getOwnPropertyNames(err).forEach(function (key) {
+    res[key] = err[key];
+  }, err);
+  return res;
+}

--- a/run/core/minio-js/package.json
+++ b/run/core/minio-js/package.json
@@ -38,6 +38,7 @@
     "gulp-sourcemaps": "*",
     "jshint-stylish": "*",
     "mocha": "*",
+    "mocha-steps": "*",
     "nock": "*",
     "rewire": "*",
     "superagent": "*"

--- a/run/core/minio-js/run.sh
+++ b/run/core/minio-js/run.sh
@@ -25,4 +25,4 @@ output_log_file="$1"
 error_log_file="$2"
 
 # run tests
-npm test 1>"$output_log_file" 2>"$error_log_file"
+./node_modules/mocha/bin/mocha -R minioreporter -b 1>"$output_log_file" 2>"$error_log_file"


### PR DESCRIPTION
Add reporter file and the corresponding change in run script and package json to support JSON logging format in minio-js.
Fixes (#136)