### PR TITLE
Remove SKIP_TESTS env var option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ RUN apt-get --yes update && apt-get --yes upgrade && apt-get --yes --quiet insta
 
 WORKDIR /mint
 
-CMD ["/mint/mint.sh"]
+ENTRYPOINT ["/mint/entrypoint.sh"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -56,4 +56,5 @@ COPY postinstall.sh /mint
 RUN /mint/postinstall.sh
 
 COPY mint.sh /mint/mint.sh
-CMD ["/mint/mint.sh"]
+COPY entrypoint.sh /mint/entrypoint.sh
+ENTRYPOINT ["/mint/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -23,8 +23,7 @@ Set environment variables to pass test target server details to the docker conta
 - `ACCESS_KEY`     - Access Key of the server. Defaults to Minio Play Access Key.
 - `SECRET_KEY`     - Secret Key of the server. Defaults to Minio Play Secret Key.
 - `ENABLE_HTTPS`   - Set to 1 to send HTTPS requests on SSL enabled deployment. Defaults to 0.
-- `MINT_DATA_DIR`       - Data directory for SDK tests. Defaults to data directory created by `build/data/install.sh` script.
-- `SKIP_TESTS`     - `','` separated list of SDKs to ignore running. Empty by default. For example, to skip `minio-js` and `awscli` tests, use `export SKIP_TESTS=minio-js,awscli`.
+- `MINT_DATA_DIR`  - Data directory for SDK tests. Defaults to data directory created by `build/data/install.sh` script.
 
 Note: With no env variables provided the tests are run on play.minio.io by default
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+#
+#  Mint (C) 2017 Minio, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+./mint.sh "$@"  &
+
+# Get the pid to be used for kill command if required
+main_pid="$!"
+trap 'echo -e "\nAborting Mint..."; kill $main_pid' SIGINT SIGTERM
+wait


### PR DESCRIPTION
User can pass comma separated names of SDKs to be run in Mint tests.

Fixes: https://github.com/minio/mint/issues/134