### PR TITLE
Fixes the delete object issue for docker environment

### DIFF
--- a/run/core/aws-sdk-ruby/aws-stub-tests.rb
+++ b/run/core/aws-sdk-ruby/aws-stub-tests.rb
@@ -81,7 +81,7 @@ class AwsSdkRubyTest
       end
     end
   rescue => e
-    raise "Failed to clean-up bucket '#{bucket_name}': #{e}"
+    raise "Failed to clean-up bucket '#{bucket_name}', #{e}"
   end
 
   #
@@ -207,10 +207,10 @@ class AwsSdkRubyTest
     file_name = ''
     @@s3.bucket(bucket_name).objects.each do |obj|
       file_name = obj.key
-      obj.delete obj.key
+      obj.delete
     end
   rescue => e
-    raise e
+    raise "File name: '#{file_name}', #{e}"
   end
 
   def removeObjectsWrapper(bucket_name, log_output)


### PR DESCRIPTION
Fixes issue #142
After new AWS Ruby SDK version 3 is made available recently last month, argument for object/file delete api is modified. That was the cause of the problem, which means there is a backward compatibility issue between previous version of AWS Ruby SDK and the latest version.