### PR TITLE
Remove negative test for invalid object name /2123123\123

### DIFF
--- a/run/core/awscli/test.sh
+++ b/run/core/awscli/test.sh
@@ -627,22 +627,7 @@ function test_put_object_error() {
     bucket_name=$(make_bucket)  
     rv=$?
 
-    # if make bucket succeeds upload a file with invalid object_name
-    if [ $rv -eq 0 ]; then
-        function="${AWS} s3api put-object --body ${MINT_DATA_DIR}/datafile-1-MB --bucket ${bucket_name} --key /2123123\123"
-        out=$($function 2>&1)
-        rv=$?
-        if [ $rv -ne 255 ]; then
-            rv=1
-        else 
-            rv=0
-        fi
-    else 
-        # if make bucket fails, $bucket_name has the error output
-        out="${bucket_name}"
-    fi
-
-    # upload an object without content-md5.
+    # if make bucket succeeds upload an object without content-md5.
     if [ $rv -eq 0 ]; then
         function="${AWS} s3api put-object --body ${MINT_DATA_DIR}/datafile-1-MB --bucket ${bucket_name} --key datafile-1-MB --content-md5 invalid"
         test_function=${function}


### PR DESCRIPTION
Minio server doesn't allow object names like /2123123\\123, while S3
allows it, so object creation with key /2123123\\123 passes with s3
gateway (awscli responds with ETAG in case of success, making mint json log
unparseable). Since there is no way to distinguish between Minio Gateway and
Server in Mint, this PR updates the test case to allow if the object
with key /2123123\\123 get uploaded to the Mint test target endpoint.

Fixes: https://github.com/minio/mint/issues/167