### PR TITLE
Fix aws ruby and minio-js behavior when invalid endpoint is passed

### DIFF
--- a/run/core/aws-sdk-ruby/aws-stub-tests.rb
+++ b/run/core/aws-sdk-ruby/aws-stub-tests.rb
@@ -67,7 +67,7 @@ class AwsSdkRubyTest
     # Get rid of the log_output fields if nil
     puts log_output.delete_if{|k, value| value == nil}.to_json
     # Exit at the first failure
-    exit if log_output[:status] == 'FAIL'
+    exit 1 if log_output[:status] == 'FAIL'
   end
 
   def cleanUp(buckets, log_output)

--- a/run/core/minio-js/minioreporter.js
+++ b/run/core/minio-js/minioreporter.js
@@ -43,15 +43,18 @@ function GenerateJsonEntry (test, err) {
   var jsonEntry = {};
 
   jsonEntry.name = "minio-js"  
-  jsonEntry.function = res[0]
   
-  if (res[1].length) {
+  if (res.length > 0 && res[0].length) {
+    jsonEntry.function = res[0]
+  }
+  
+  if (res.length > 1 && res[1].length) {
     jsonEntry.args = res[1]
   }
 
   jsonEntry.duration = test.duration
   
-  if (res[2].length) {
+  if (res.length > 2 && res[2].length) {
     jsonEntry.alert = res[2]
   }
 


### PR DESCRIPTION
Make sure that aws-sdk-ruby and minio-js report failure,when
wrong credentials are passed.

Fixes #164