### PR TITLE
add mint mode to aws-sdk-php tests

### DIFF
--- a/run/core/aws-sdk-php/quick-tests.php
+++ b/run/core/aws-sdk-php/quick-tests.php
@@ -1030,6 +1030,7 @@ $GLOBALS['access_key'] = getenv("ACCESS_KEY");
 $GLOBALS['secret_key'] = getenv("SECRET_KEY");
 $GLOBALS['endpoint'] = getenv("SERVER_ENDPOINT");
 $GLOBALS['secure'] = getenv("ENABLE_HTTPS");
+$GLOBALS['mint_mode'] = getenv("MINT_MODE");
 
 /**
  * @global string $GLOBALS['MINT_DATA_DIR']
@@ -1085,6 +1086,11 @@ $objects =  [
     randomName() => 'obj1',
     randomName() => 'obj2',
 ];
+
+if (!($GLOBALS['mint_mode'] == "core" || $GLOBALS['mint_mode'] == "full" )) {
+    // Unknown mint mode
+    exit(1);
+}
 
 try {
     initSetup($s3Client, $objects);


### PR DESCRIPTION
As there is no extensive tests in aws-sdk-php tests, currently all the
tests are run for MINT_MODE `core` and `full`.