### PR TITLE
Mocha version 4.0.0 requires explicit flag to exit tests

### DIFF
--- a/run/core/minio-js/run.sh
+++ b/run/core/minio-js/run.sh
@@ -25,4 +25,4 @@ output_log_file="$1"
 error_log_file="$2"
 
 # run tests
-./node_modules/mocha/bin/mocha -R minioreporter -b 1>>"$output_log_file" 2>"$error_log_file"
+./node_modules/mocha/bin/mocha -R minioreporter -b --exit 1>>"$output_log_file" 2>"$error_log_file"


### PR DESCRIPTION
Mocha version 4.0.0 and above seems to hang functional tests
if --exit flag is not passed.

Added --exit flag to where mocha is being executed in run.sh

Fixes #163