### PR TITLE
Fail if directory passed from cmd line doesn't exist

### DIFF
--- a/mint.sh
+++ b/mint.sh
@@ -125,6 +125,10 @@ function main()
     i=1
     for sdk_dir in "${run_list[@]}"; do
         sdk_name=$(basename "$sdk_dir")
+        if [ ! -d "$sdk_dir" ]; then
+            echo "Test $sdk_name not found. Exiting Mint."
+            exit 1
+        fi
         echo -n "($i/$count) Running $sdk_name tests ... "
         if ! run_test "$sdk_dir"; then
             break


### PR DESCRIPTION
Mint accepts command line args to run specific tests. This PR adds a check to make sure the test directory exists before attempting to run tests. 