### PR TITLE
Add new mint arg to test virtual host style with awscli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,10 @@ ENV GOPATH /usr/local
 
 ENV PATH $GOPATH/bin:$GOROOT/bin:$PATH
 
+COPY dnsmasq.conf /etc/dnsmasq.conf
+
+EXPOSE 53/udp
+
 RUN apt-get --yes update && apt-get --yes upgrade && apt-get --yes --quiet install wget jq curl git && \
     git clone https://github.com/minio/mint.git /mint && \
     cd /mint && /mint/release.sh

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -12,6 +12,10 @@ ENV PATH $GOPATH/bin:$GOROOT/bin:$PATH
 
 WORKDIR /mint
 
+COPY dnsmasq.conf /etc/dnsmasq.conf
+
+EXPOSE 53/udp
+
 RUN apt-get --yes update && apt-get --yes upgrade && apt-get --yes --quiet install wget jq curl
 
 ENV MINT_ROOT_DIR /mint

--- a/README.md
+++ b/README.md
@@ -39,7 +39,27 @@ Below environment variables are required to be passed to the docker container. S
 | `ACCESS_KEY` | Access key of access `SERVER_ENDPOINT` | `Q3AM3UQ867SPQQA43P2F` |
 | `SECRET_KEY` | Secret Key of access `SERVER_ENDPOINT` | `zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG` |
 | `ENABLE_HTTPS` | (Optional) Set `1` to indicate to use HTTPS to access `SERVER_ENDPOINT`. Defaults to `0` (HTTP) | `1` |
-| `MINT_MODE` | (Optional) Set mode indicating what catogery of tests to be run by values `core` or `full`.  Defaults to `core` | `full` |
+| `MINT_MODE` | (Optional) Set mode indicating what category of tests to be run by values `core` or `full`.  Defaults to `core` | `full` |
+| `ENABLE_VIRTUAL_STYLE` | (Optional) Set `1` to enable virtual style access to `SERVER_ENDPOINT`. Defaults to `0` (Path style) | `1` |
+
+### Test virtual style access against Minio server
+
+To test Minio server virtual style access with Mint, follow these steps:
+
+- Set a domain in your Minio server using environment variable MINIO_DOMAIN. For example `export MINIO_DOMAIN=mydomain.com`.
+- Start Minio server.
+- For testing Minio server via domain `mydomain.com` or sub-domain name like `bucket-name.mydomain.com`, the domain should be resolvable from Mint container via DNS. Mint uses the domain
+`mydomain.com` for testing purposes. This is configured via `dnsmasq`. Edit the `dnsmasq` [config file](./dnsmasq.conf) and build custom Docker image to change this setting.
+- You can execute Mint against Minio server (with `MINIO_DOMAIN` set to `mydomain.com`) using this command,
+
+
+```sh
+$ sudo docker run -e "SERVER_ENDPOINT=minio.com:9000" -e "ACCESS_KEY=minio" \
+-e "SECRET_KEY=minio123" -e "ENABLE_HTTPS=0" -e "ENABLE_VIRTUAL_STYLE=1" \
+--net=host --add-host="mydomain.com:127.0.0.1" minio/mint awscli
+```
+
+We set the `ENABLE_VIRTUAL_STYLE` flag to `1` to indicate that virtual style tests be run.
 
 ### Mint log format
 

--- a/dnsmasq.conf
+++ b/dnsmasq.conf
@@ -1,0 +1,1 @@
+address=/mydomain.com/127.0.0.1

--- a/mint.sh
+++ b/mint.sh
@@ -20,6 +20,7 @@ MINT_DATA_DIR=${MINT_DATA_DIR:-/mint/data}
 MINT_MODE=${MINT_MODE:-core}
 SERVER_REGION=${SERVER_REGION:-us-east-1}
 ENABLE_HTTPS=${ENABLE_HTTPS:-0}
+ENABLE_VIRTUAL_STYLE=${ENABLE_VIRTUAL_STYLE:-0}
 
 if [ -z "$SERVER_ENDPOINT" ]; then
     SERVER_ENDPOINT="play.minio.io:9000"
@@ -95,17 +96,19 @@ function main()
     export SERVER_ENDPOINT
     export ACCESS_KEY
     export SECRET_KEY
-    export ENABLE_HTTPS
     export SERVER_REGION
+    export ENABLE_HTTPS
+    export ENABLE_VIRTUAL_STYLE
 
     echo "Running with"
-    echo "SERVER_ENDPOINT: $SERVER_ENDPOINT"
-    echo "ACCESS_KEY:      $ACCESS_KEY"
-    echo "SECRET_KEY:      ***REDACTED***"
-    echo "ENABLE_HTTPS:    $ENABLE_HTTPS"
-    echo "SERVER_REGION:   $SERVER_REGION"
-    echo "MINT_DATA_DIR:   $MINT_DATA_DIR"
-    echo "MINT_MODE:       $MINT_MODE"
+    echo "SERVER_ENDPOINT:      $SERVER_ENDPOINT"
+    echo "ACCESS_KEY:           $ACCESS_KEY"
+    echo "SECRET_KEY:           ***REDACTED***"
+    echo "ENABLE_HTTPS:         $ENABLE_HTTPS"
+    echo "SERVER_REGION:        $SERVER_REGION"
+    echo "MINT_DATA_DIR:        $MINT_DATA_DIR"
+    echo "MINT_MODE:            $MINT_MODE"
+    echo "ENABLE_VIRTUAL_STYLE: $ENABLE_VIRTUAL_STYLE"
     echo
 
     echo "To get logs, run 'sudo docker cp ${CONTAINER_ID}:/mint/log /tmp/mint-logs'"

--- a/run/core/awscli/run.sh
+++ b/run/core/awscli/run.sh
@@ -29,9 +29,18 @@ aws configure set aws_access_key_id "$ACCESS_KEY"
 aws configure set aws_secret_access_key "$SECRET_KEY"
 aws configure set default.region "$SERVER_REGION"
 
-# run tests
+# Setup endpoint scheme
 endpoint="http://$SERVER_ENDPOINT"
 if [ "$ENABLE_HTTPS" -eq 1 ]; then
     endpoint="https://$SERVER_ENDPOINT"
 fi
+
+# check the access style and run tests if virtual style is set
+if [ "$ENABLE_VIRTUAL_STYLE" -eq 1 ]; then
+    aws configure set default.s3.addressing_style virtual
+    ./test.sh "$endpoint"  1>>"$output_log_file" 2>"$error_log_file"
+fi
+
+# run path style tests
+aws configure set default.s3.addressing_style path
 ./test.sh "$endpoint"  1>>"$output_log_file" 2>"$error_log_file"


### PR DESCRIPTION
Fixes https://github.com/minio/mint/issues/213,  should be merged after https://github.com/minio/minio/pull/5095

Assumption is either the domain on which Minio server is running is already resolvable by the host that is running Mint 

or 

we add hosts to the docker container, that can be done like this:

```sh
$ sudo docker run -e "SERVER_ENDPOINT=minio.com:9000" -e "ACCESS_KEY=minio" \
-e "SECRET_KEY=minio123" -e "ENABLE_HTTPS=0" -e "ENABLE_VIRTUAL_STYLE=1" \
--net=host --add-host="minio.com:127.0.0.1" \
--add-host="awscli-mint-test-bucket.minio.com:127.0.0.1" minio/mint awscli
```