### PR TITLE
Fix aws-sdk-go test behavior

### DIFF
--- a/run/core/aws-sdk-go/quick-tests.go
+++ b/run/core/aws-sdk-go/quick-tests.go
@@ -25,7 +25,6 @@ import (
 	"encoding/xml"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"net/http"
 	"os"
@@ -127,10 +126,29 @@ func randString(n int, src rand.Source, prefix string) string {
 	return prefix + string(b[0:30-len(prefix)])
 }
 
-func testPresignedPut(s3Client *s3.S3) {
+func cleanup(s3Client *s3.S3, bucket string, object string, function string,
+	args map[string]interface{}, startTime time.Time) {
+
+	// Deleting the object, just in case it was created. Will not check for errors.
+	s3Client.DeleteObject(&s3.DeleteObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(object),
+	})
+
+	_, err := s3Client.DeleteBucket(&s3.DeleteBucketInput{
+		Bucket: aws.String(bucket),
+	})
+	if err != nil {
+		failureLog(function, args, startTime, "", "AWS SDK Go DeleteBucket Failed", err).Fatal()
+		return
+	}
+
+}
+
+func testPresignedPutInvalidHash(s3Client *s3.S3) {
 	startTime := time.Now()
 	function := "PresignedPut"
-	bucket := randString(60, rand.NewSource(time.Now().UnixNano()), "aws-sdk-go-test")
+	bucket := randString(60, rand.NewSource(time.Now().UnixNano()), "aws-sdk-go-test-")
 	object := "presignedTest"
 	expiry := 1 * time.Minute
 	args := map[string]interface{}{
@@ -138,6 +156,15 @@ func testPresignedPut(s3Client *s3.S3) {
 		"objectName": object,
 		"expiry":     expiry,
 	}
+
+	_, err := s3Client.CreateBucket(&s3.CreateBucketInput{
+		Bucket: aws.String(bucket),
+	})
+	if err != nil {
+		failureLog(function, args, startTime, "", "AWS SDK Go CreateBucket Failed", err).Fatal()
+		return
+	}
+	defer cleanup(s3Client, bucket, object, function, args, startTime)
 
 	req, _ := s3Client.PutObjectRequest(&s3.PutObjectInput{
 		Bucket:      aws.String(bucket),
@@ -161,15 +188,11 @@ func testPresignedPut(s3Client *s3.S3) {
 		failureLog(function, args, startTime, "", "AWS SDK Go presigned put request failed", err).Fatal()
 		return
 	}
-	body, err := ioutil.ReadAll(resp.Body)
-	resp.Body.Close()
-	if err != nil {
-		failureLog(function, args, startTime, "", "AWS SDK Go reading response body failed", err).Fatal()
-		return
-	}
+	defer resp.Body.Close()
 
+	dec := xml.NewDecoder(resp.Body)
 	errResp := ErrorResponse{}
-	err = xml.Unmarshal(body, &errResp)
+	err = dec.Decode(&errResp)
 	if err != nil {
 		failureLog(function, args, startTime, "", "AWS SDK Go unmarshalling xml failed", err).Fatal()
 		return
@@ -179,6 +202,7 @@ func testPresignedPut(s3Client *s3.S3) {
 		failureLog(function, args, startTime, "", fmt.Sprintf("AWS SDK Go presigned PUT expected to fail with XAmzContentSHA256Mismatch but got %v", errResp.Code), errors.New("AWS S3 error code mismatch")).Fatal()
 		return
 	}
+
 	successLogger(function, args, startTime).Info()
 }
 
@@ -189,7 +213,7 @@ func main() {
 	secure := os.Getenv("ENABLE_HTTPS")
 	sdkEndpoint := "http://" + endpoint
 	if secure == "1" {
-		sdkEndpoint = "https://"
+		sdkEndpoint = "https://" + endpoint
 	}
 
 	creds := credentials.NewStaticCredentials(accessKey, secretKey, "")
@@ -200,8 +224,6 @@ func main() {
 		Region:           aws.String("us-east-1"),
 		S3ForcePathStyle: aws.Bool(true),
 	}
-
-	s3Config = s3Config.WithLogLevel(aws.LogDebug)
 
 	// Create an S3 service object in the default region.
 	s3Client := s3.New(newSession, s3Config)
@@ -215,5 +237,5 @@ func main() {
 	// log Info or above -- success cases are Info level, failures are Fatal level
 	log.SetLevel(log.InfoLevel)
 	// execute tests
-	testPresignedPut(s3Client)
+	testPresignedPutInvalidHash(s3Client)
 }


### PR DESCRIPTION
Added missing endpoint entry in the case of secure endpoint.
Added bucket creation and deletion code, as the error code is different
between AWS S3 and Minio server, if test is run with a non-existent bucket.

Fixes #228