### PR TITLE
Fix log parsing to check for lowercase fail in status

### DIFF
--- a/mint.sh
+++ b/mint.sh
@@ -78,7 +78,7 @@ function run_test()
         fi
         ## Show error.log when status is empty or not "FAIL".
         ## This may happen when test run failed without providing logs.
-        if [ "$jq_rv" -ne 0 ] || [ -z "$status" ] || [ "$status" != "FAIL" ]; then
+        if [ "$jq_rv" -ne 0 ] || [ -z "$status" ] || ([ "$status" != "FAIL" ] && [ "$status" != "fail" ]); then
             cat "$BASE_LOG_DIR/$sdk_name/$ERROR_FILE"
         else
             jq . <<<"$entry"


### PR DESCRIPTION
Fixes #233 

While https://github.com/minio/minio-go/pull/865 updates the minio-go logs to print `FAIL` as status instead of `fail`, to avoid further issues, we should check for both values in Mint as well. 