### PR TITLE
minio-py: Always install last pip version

### DIFF
--- a/build/minio-py/install.sh
+++ b/build/minio-py/install.sh
@@ -22,6 +22,7 @@ if [ -z "$MINIO_PY_VERSION" ]; then
 fi
 
 test_run_dir="$MINT_RUN_CORE_DIR/minio-py"
+pip3 install --upgrade pip
 pip3 install --user faker
 pip3 install minio=="$MINIO_PY_VERSION"
 $WGET --output-document="$test_run_dir/tests.py" "https://raw.githubusercontent.com/minio/minio-py/${MINIO_PY_VERSION}/tests/functional/tests.py"


### PR DESCRIPTION
Building a mint image is currently failing with the following message:

```
You are using pip version 8.1.1, however version 9.0.3 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
The command '/bin/sh -c build/minio-py/install.sh' returned a non-zero code: 1
```

With this PR, we always install the last pip version.

Fixes #270 