### PR TITLE
Add retry to curl command when contacting Github API

### DIFF
--- a/build/mc/install.sh
+++ b/build/mc/install.sh
@@ -15,7 +15,7 @@
 #  limitations under the License.
 #
 
-MC_VERSION=$(curl -s https://api.github.com/repos/minio/mc/releases/latest | jq -r .tag_name)
+MC_VERSION=$(curl --retry 10 -s https://api.github.com/repos/minio/mc/releases/latest | jq -r .tag_name)
 if [ -z "$MC_VERSION" ]; then
     echo "unable to get mc version from github"
     exit 1

--- a/build/minio-dotnet/install.sh
+++ b/build/minio-dotnet/install.sh
@@ -19,7 +19,7 @@ set -e
 
 MINIO_DOTNET_SDK_PATH="$MINT_RUN_CORE_DIR/minio-dotnet"
 
-MINIO_DOTNET_SDK_VERSION=$(curl -s https://api.github.com/repos/minio/minio-dotnet/releases/latest | jq -r .tag_name)
+MINIO_DOTNET_SDK_VERSION=$(curl --retry 10 -s https://api.github.com/repos/minio/minio-dotnet/releases/latest | jq -r .tag_name)
 if [ -z "$MINIO_DOTNET_SDK_VERSION" ]; then
     echo "unable to get minio-dotnet version from github"
     exit 1

--- a/build/minio-go/install.sh
+++ b/build/minio-go/install.sh
@@ -15,7 +15,7 @@
 #  limitations under the License.
 #
 
-MINIO_GO_VERSION=$(curl -s https://api.github.com/repos/minio/minio-go/releases/latest | jq -r .tag_name)
+MINIO_GO_VERSION=$(curl --retry 10 -s https://api.github.com/repos/minio/minio-go/releases/latest | jq -r .tag_name)
 if [ -z "$MINIO_GO_VERSION" ]; then
     echo "unable to get minio-go version from github"
     exit 1

--- a/build/minio-java/install.sh
+++ b/build/minio-java/install.sh
@@ -15,7 +15,7 @@
 #  limitations under the License.
 #
 
-MINIO_JAVA_VERSION=$(curl -s https://api.github.com/repos/minio/minio-java/releases/latest | jq -r .tag_name)
+MINIO_JAVA_VERSION=$(curl --retry 10 -s https://api.github.com/repos/minio/minio-java/releases/latest | jq -r .tag_name)
 if [ -z "$MINIO_JAVA_VERSION" ]; then
     echo "unable to get minio-java version from github"
     exit 1

--- a/build/minio-js/install.sh
+++ b/build/minio-js/install.sh
@@ -15,7 +15,7 @@
 #  limitations under the License.
 #
 
-MINIO_JS_VERSION=$(curl -s https://api.github.com/repos/minio/minio-js/releases/latest | jq -r .tag_name)
+MINIO_JS_VERSION=$(curl --retry 10 -s https://api.github.com/repos/minio/minio-js/releases/latest | jq -r .tag_name)
 if [ -z "$MINIO_JS_VERSION" ]; then
     echo "unable to get minio-js version from github"
     exit 1

--- a/build/minio-py/install.sh
+++ b/build/minio-py/install.sh
@@ -15,7 +15,7 @@
 #  limitations under the License.
 #
 
-MINIO_PY_VERSION=$(curl -s https://api.github.com/repos/minio/minio-py/releases/latest | jq -r .tag_name)
+MINIO_PY_VERSION=$(curl --retry 10 -s https://api.github.com/repos/minio/minio-py/releases/latest | jq -r .tag_name)
 if [ -z "$MINIO_PY_VERSION" ]; then
     echo "unable to get minio-py version from github"
     exit 1


### PR DESCRIPTION
Build in travis fails sometimes, we expect it is only a timeout
issue hence adding a retry to curl command.