### PR TITLE
[awscli] Should stop the execution incase of a test case failure

### DIFF
--- a/run/core/awscli/test.sh
+++ b/run/core/awscli/test.sh
@@ -258,13 +258,6 @@ function test_lookup_object_prefix() {
         return 1
     fi
 
-    # Lookup for the right prefix.
-    function="${AWS} s3api head-object --bucket ${bucket_name} --key prefix/directory/"
-    # save the ref to function being tested, so it can be logged
-    test_function=${function}
-    out=$($function 2>&1)
-
-    rv=$?
     if [ $rv -ne 0 ]; then
         # clean up and log error
         ${AWS} s3 rb s3://"${bucket_name}" --force > /dev/null 2>&1
@@ -1203,7 +1196,7 @@ main() {
     test_multipart_upload_10 && \
     test_serverside_encryption && \
     test_serverside_encryption_get_range && \
-    test_serverside_encryption_multipart
+    test_serverside_encryption_multipart && \
     # Success cli ops.
     test_aws_s3_cp && \
     test_aws_s3_sync && \


### PR DESCRIPTION
This PR fixes
- Bars the execution of the remaining test cases incase of a test case failure inbetween.
- Removes the unwanted `head-object` test case, Because this wont apply for both s3/minio [Tested]
  
<b>s3</b>
![image](https://user-images.githubusercontent.com/5410427/47565048-c0c5eb80-d944-11e8-805a-f8ce5eec4e55.png)

<b>minio</b>
![image](https://user-images.githubusercontent.com/5410427/47565118-fbc81f00-d944-11e8-93fb-5213d11042af.png)

And the reason for removing the unwanted test case is because

We already do a `delete-object` [https://github.com/minio/mint/blob/c5035ea2fa7f979a98f6a961d8ecc1ce77611672/run/core/awscli/test.sh#L228](url), We should expect a `400`.

And we already have similar `head-object` test [https://github.com/minio/mint/blob/c5035ea2fa7f979a98f6a961d8ecc1ce77611672/run/core/awscli/test.sh#L246](url). 




Fixes #296 