### PR TITLE
versioning: Do not check for ETag since it is not md5sum

### DIFF
--- a/build/versioning/put.go
+++ b/build/versioning/put.go
@@ -24,12 +24,15 @@ import (
 	"fmt"
 	"math/rand"
 	"net/url"
+	"regexp"
 	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
 )
+
+var etagRegex = regexp.MustCompile(`\"(.*)\"`)
 
 // Put two objects with the same name but with different content
 func testPutObject() {
@@ -124,7 +127,7 @@ func testPutObject() {
 		return
 	}
 
-	if *vid1.ETag != "\"e847032b45d3d76230058a80d8ca909b\"" || *vid2.ETag != "\"094459df8fcebffc70d9aa08d75f9944\"" {
+	if !etagRegex.MatchString(*vid1.ETag) || !etagRegex.MatchString(*vid2.ETag) {
 		failureLog(function, args, startTime, "", "Unexpected list content", errors.New("unexpected ETag field")).Fatal()
 		return
 	}

--- a/build/versioning/stat.go
+++ b/build/versioning/stat.go
@@ -113,13 +113,12 @@ func testStatObject() {
 	testCases := []struct {
 		size         int64
 		versionId    string
-		etag         string
 		contentType  string
 		deleteMarker bool
 	}{
-		{0, *(*result.DeleteMarkers[0]).VersionId, "", "", true},
-		{14, *(*result.Versions[0]).VersionId, "\"e847032b45d3d76230058a80d8ca909b\"", "binary/octet-stream", false},
-		{12, *(*result.Versions[1]).VersionId, "\"094459df8fcebffc70d9aa08d75f9944\"", "binary/octet-stream", false},
+		{0, *(*result.DeleteMarkers[0]).VersionId, "", true},
+		{14, *(*result.Versions[0]).VersionId, "binary/octet-stream", false},
+		{12, *(*result.Versions[1]).VersionId, "binary/octet-stream", false},
 	}
 
 	for i, testCase := range testCases {
@@ -158,7 +157,7 @@ func testStatObject() {
 			return
 		}
 
-		if *result.ETag != testCase.etag {
+		if !etagRegex.MatchString(*result.ETag) {
 			failureLog(function, args, startTime, "", fmt.Sprintf("StatObject (%d) unexpected ETag", i+1), err).Fatal()
 			return
 		}


### PR DESCRIPTION
Do not expect a well defined ETag values in the versioning tests since
it is not always md5sum, e.g. when auto encryption is enabled in server
side.