### PR TITLE
Add more entropy to random name generated during PHP tests

### DIFF
--- a/run/core/aws-sdk-php/quick-tests.php
+++ b/run/core/aws-sdk-php/quick-tests.php
@@ -64,7 +64,7 @@ class ClientConfig {
   * @return string
   */
 function randomName():string {
-    return uniqid("aws-sdk-php-");
+    return str_replace('.', '', uniqid('aws-sdk-php-', true));
 }
 
  /**


### PR DESCRIPTION
I have seen values `uniqid()` produces to be quite similar, and
according to https://www.php.net/uniqid it's not guaranteed to
produce a unique value as it's based on the system clock.

This change sets the `more_entropy` parameter to increase the
likelihood that the value returned is unique. I also removed the
dot generated in the resulting value, incase it causes problems
with tests.