### PR TITLE
don't install documentation for ruby dependencies

### DIFF
--- a/build/aws-sdk-ruby/install.sh
+++ b/build/aws-sdk-ruby/install.sh
@@ -15,4 +15,4 @@
 #  limitations under the License.
 #
 
-gem install aws-sdk-resources aws-sdk multipart_body
+gem install --no-document aws-sdk-resources aws-sdk multipart_body


### PR DESCRIPTION
this was previously set to --no-ri --no-rdoc before updating the
container to Ubuntu 20.04. Latest version of gem now uses
--no-document as an equivalent of those parameters.