### PR TITLE
Fix ip check when ENABLE_VIRTUAL_STYLE=1 is set

### DIFF
--- a/mint.sh
+++ b/mint.sh
@@ -35,7 +35,7 @@ if [ "$ENABLE_VIRTUAL_STYLE" -eq 1 ]; then
         SERVER_IP="${SERVER_ENDPOINT%%:*}"
         SERVER_PORT="${SERVER_ENDPOINT/*:/}"
         # Check if SERVER_IP is actually IPv4 address
-        octets=("${SERVER_IP//./ }")
+        IFS=. read -ra octets <<< "$SERVER_IP"
         if [ "${#octets[@]}" -ne 4 ]; then
             echo "$SERVER_IP must be an IP address"
             exit 1


### PR DESCRIPTION
I was getting an error "127.0.0.1 must be an IP address" when
running mint with ENABLE_VIRTUAL_STYLE=1. The check for octets
doesn't quite work as the array size is 1 instead of 4. Using
read command with IFS set to a dot fixes this issue.