### PR TITLE
awscli: Use botocore with expect 100 continue fix

### DIFF
--- a/build/awscli/expect-100.py
+++ b/build/awscli/expect-100.py
@@ -1,0 +1,37 @@
+diff --git a/botocore/handlers.py b/botocore/handlers.py
+index 4b1d6445e..c8dd79c3e 100644
+--- a/botocore/handlers.py
++++ b/botocore/handlers.py
+@@ -333,9 +333,11 @@ def add_expect_header(model, params, **kwargs):
+         return
+     if 'body' in params:
+         body = params['body']
+-        if hasattr(body, 'read'):
++        size = getattr(body, "_size", None)
++        if size:
+             # Any file like object will use an expect 100-continue
+-            # header regardless of size.
++            # except when size equals zero.
++            # https://tools.ietf.org/html/rfc7231#section-5.1.1
+             logger.debug("Adding expect 100 continue header to request.")
+             params['headers']['Expect'] = '100-continue'
+ 
+diff --git a/tests/unit/test_awsrequest.py b/tests/unit/test_awsrequest.py
+index 22bd9a746..44cd05f61 100644
+--- a/tests/unit/test_awsrequest.py
++++ b/tests/unit/test_awsrequest.py
+@@ -504,6 +504,14 @@ class TestAWSHTTPConnection(unittest.TestCase):
+         response = conn.getresponse()
+         self.assertEqual(response.status, 200)
+ 
++    def test_no_expect_header_set_no_body(self):
++        s = FakeSocket(b'HTTP/1.1 200 OK\r\n')
++        conn = AWSHTTPConnection('s3.amazonaws.com', 443)
++        conn.sock = s
++        conn.request('PUT', '/bucket/foo', b'')
++        response = conn.getresponse()
++        self.assertEqual(response.status, 200)
++
+     def test_tunnel_readline_none_bugfix(self):
+         # Tests whether ``_tunnel`` function is able to work around the
+         # py26 bug of avoiding infinite while loop if nothing is returned.

--- a/build/awscli/install.sh
+++ b/build/awscli/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-#  Mint (C) 2017-2020 Minio, Inc.
+#  Mint (C) 2017-2022 Minio, Inc.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -15,4 +15,30 @@
 #  limitations under the License.
 #
 
-pip3 install awscli --upgrade
+die() {
+	echo "$*" 1>&2
+	exit 1
+}
+
+PWD="$(dirname "$(realpath $0)")"
+TMPDIR="$(mktemp -d)"
+
+cd "$TMPDIR"
+
+# Download botocore and apply @y4m4's expect 100 continue fix
+( git clone --depth 1 -b 1.27.1 https://github.com/boto/botocore && \
+	cd botocore && \
+	patch -p1 "$PWD/expect-100.patch" && \
+	python3 -m pip install . ) ||
+	die "Unable to install botocore.."
+
+
+# Download and install aws cli
+( git clone --depth 1 -b 1.25.1 https://github.com/aws/aws-cli &&
+	cd aws-cli && \
+	python3 -m pip install . ) ||
+	die "Unable to install aws-cli.."
+
+
+# Clean-up
+rm -r $TMPDIR


### PR DESCRIPTION
awscli takes too much time sometimes uploading an object
due to a bug in botocore library.

This commit applies @harshavardhana  fix for that issue and rebuild
and install botocore and AWS cli in the mint image.