### PR TITLE
Respect `SERVER_REGION` in more targets and fix various bugs

### DIFF
--- a/build/aws-sdk-java/src/FunctionalTests.java
+++ b/build/aws-sdk-java/src/FunctionalTests.java
@@ -124,7 +124,7 @@ public class FunctionalTests {
         sseKey3 = new SSECustomerKey(secretKey3);
 
         // Create bucket
-        s3Client.createBucket(new CreateBucketRequest(bucketName));
+        s3Client.createBucket(new CreateBucketRequest(bucketName, region));
     }
 
     public static void teardown() throws IOException {
@@ -582,11 +582,10 @@ public class FunctionalTests {
     public static void main(String[] args) throws Exception, IOException, NoSuchAlgorithmException {
 
         endpoint = System.getenv("SERVER_ENDPOINT");
+        region = System.getenv("SERVER_REGION");
         accessKey = System.getenv("ACCESS_KEY");
         secretKey = System.getenv("SECRET_KEY");
         enableHTTPS = System.getenv("ENABLE_HTTPS").equals("1");
-
-        region = "us-east-1";
 
         if (enableHTTPS) {
             endpoint = "https://" + endpoint;

--- a/build/versioning/bucket.go
+++ b/build/versioning/bucket.go
@@ -48,7 +48,7 @@ func testMakeBucket() {
 		failureLog(function, args, startTime, "", "Versioning CreateBucket Failed", err).Fatal()
 		return
 	}
-	defer cleanupBucket(bucketName, function, args, startTime)
+	defer cleanupBucket(bucketName, function, args, startTime, false)
 
 	putVersioningInput := &s3.PutBucketVersioningInput{
 		Bucket: aws.String(bucketName),

--- a/build/versioning/bucket.go
+++ b/build/versioning/bucket.go
@@ -31,8 +31,6 @@ import (
 
 // Tests bucket versioned bucket and get its versioning configuration to check
 func testMakeBucket() {
-	s3Client.Config.Region = aws.String("us-east-1")
-
 	// initialize logging params
 	startTime := time.Now()
 	function := "testCreateVersioningBucket"
@@ -42,6 +40,9 @@ func testMakeBucket() {
 	}
 	_, err := s3Client.CreateBucket(&s3.CreateBucketInput{
 		Bucket: aws.String(bucketName),
+		CreateBucketConfiguration: &s3.CreateBucketConfiguration{
+			LocationConstraint: s3Client.Config.Region,
+		},
 	})
 	if err != nil {
 		failureLog(function, args, startTime, "", "Versioning CreateBucket Failed", err).Fatal()

--- a/build/versioning/delete.go
+++ b/build/versioning/delete.go
@@ -51,7 +51,7 @@ func testDeleteObject() {
 		failureLog(function, args, startTime, "", "CreateBucket failed", err).Fatal()
 		return
 	}
-	defer cleanupBucket(bucket, function, args, startTime)
+	defer cleanupBucket(bucket, function, args, startTime, false)
 
 	putVersioningInput := &s3.PutBucketVersioningInput{
 		Bucket: aws.String(bucket),
@@ -194,7 +194,7 @@ func testDeleteObjects() {
 		failureLog(function, args, startTime, "", "CreateBucket failed", err).Fatal()
 		return
 	}
-	defer cleanupBucket(bucket, function, args, startTime)
+	defer cleanupBucket(bucket, function, args, startTime, false)
 
 	putVersioningInput := &s3.PutBucketVersioningInput{
 		Bucket: aws.String(bucket),

--- a/build/versioning/get.go
+++ b/build/versioning/get.go
@@ -52,7 +52,7 @@ func testGetObject() {
 		failureLog(function, args, startTime, "", "CreateBucket failed", err).Fatal()
 		return
 	}
-	defer cleanupBucket(bucket, function, args, startTime)
+	defer cleanupBucket(bucket, function, args, startTime, false)
 
 	putVersioningInput := &s3.PutBucketVersioningInput{
 		Bucket: aws.String(bucket),

--- a/build/versioning/list.go
+++ b/build/versioning/list.go
@@ -34,8 +34,9 @@ import (
 )
 
 // Test regular listing result with simple use cases:
-//   Upload an object ten times, delete it once (delete marker)
-//   and check listing result
+//
+//	Upload an object ten times, delete it once (delete marker)
+//	and check listing result
 func testListObjectVersionsSimple() {
 	startTime := time.Now()
 	function := "testListObjectVersionsSimple"
@@ -55,7 +56,7 @@ func testListObjectVersionsSimple() {
 		failureLog(function, args, startTime, "", "CreateBucket failed", err).Fatal()
 		return
 	}
-	defer cleanupBucket(bucket, function, args, startTime)
+	defer cleanupBucket(bucket, function, args, startTime, false)
 
 	putVersioningInput := &s3.PutBucketVersioningInput{
 		Bucket: aws.String(bucket),
@@ -241,7 +242,7 @@ func testListObjectVersionsWithPrefixAndDelimiter() {
 		failureLog(function, args, startTime, "", "CreateBucket failed", err).Fatal()
 		return
 	}
-	defer cleanupBucket(bucket, function, args, startTime)
+	defer cleanupBucket(bucket, function, args, startTime, false)
 
 	putVersioningInput := &s3.PutBucketVersioningInput{
 		Bucket: aws.String(bucket),
@@ -382,7 +383,7 @@ func testListObjectVersionsKeysContinuation() {
 		failureLog(function, args, startTime, "", "CreateBucket failed", err).Fatal()
 		return
 	}
-	defer cleanupBucket(bucket, function, args, startTime)
+	defer cleanupBucket(bucket, function, args, startTime, false)
 
 	putVersioningInput := &s3.PutBucketVersioningInput{
 		Bucket: aws.String(bucket),
@@ -488,7 +489,7 @@ func testListObjectVersionsVersionIDContinuation() {
 		failureLog(function, args, startTime, "", "CreateBucket failed", err).Fatal()
 		return
 	}
-	defer cleanupBucket(bucket, function, args, startTime)
+	defer cleanupBucket(bucket, function, args, startTime, false)
 
 	putVersioningInput := &s3.PutBucketVersioningInput{
 		Bucket: aws.String(bucket),
@@ -597,7 +598,7 @@ func testListObjectsVersionsWithEmptyDirObject() {
 		failureLog(function, args, startTime, "", "CreateBucket failed", err).Fatal()
 		return
 	}
-	defer cleanupBucket(bucket, function, args, startTime)
+	defer cleanupBucket(bucket, function, args, startTime, false)
 
 	putVersioningInput := &s3.PutBucketVersioningInput{
 		Bucket: aws.String(bucket),

--- a/build/versioning/main.go
+++ b/build/versioning/main.go
@@ -16,6 +16,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"time"
 
@@ -29,7 +30,8 @@ import (
 // S3 client for testing
 var s3Client *s3.S3
 
-func cleanupBucket(bucket string, function string, args map[string]interface{}, startTime time.Time) {
+// bypassGovernanceRetention is necessary as always setting BypassGovernanceRetention results in API errors on buckets without Object Locking enabled.
+func cleanupBucket(bucket string, function string, args map[string]interface{}, startTime time.Time, bypassGovernanceRetention bool) {
 	start := time.Now()
 
 	input := &s3.ListObjectVersionsInput{
@@ -41,35 +43,53 @@ func cleanupBucket(bucket string, function string, args map[string]interface{}, 
 			func(page *s3.ListObjectVersionsOutput, lastPage bool) bool {
 				for _, v := range page.Versions {
 					input := &s3.DeleteObjectInput{
-						Bucket:                    &bucket,
-						Key:                       v.Key,
-						VersionId:                 v.VersionId,
-						BypassGovernanceRetention: aws.Bool(true),
+						Bucket:    &bucket,
+						Key:       v.Key,
+						VersionId: v.VersionId,
 					}
+					// Set BypassGovernanceRetention in separate step. Setting the value in the DeleteObjectInput may lead to the header being present with a value of false.
+					// This is not allowed by the S3 API and will result in a 409 error, if Object Locking is disabled.
+					if bypassGovernanceRetention {
+						input.SetBypassGovernanceRetention(true)
+					}
+
 					_, err := s3Client.DeleteObject(input)
 					if err != nil {
-						return true
+						fmt.Printf("Unable to delete object version %s in %s, retrying after 30 seconds: %s\n", *v.Key, bucket, err.Error())
+						return false
 					}
 				}
 				for _, v := range page.DeleteMarkers {
 					input := &s3.DeleteObjectInput{
-						Bucket:                    &bucket,
-						Key:                       v.Key,
-						VersionId:                 v.VersionId,
-						BypassGovernanceRetention: aws.Bool(true),
+						Bucket:    &bucket,
+						Key:       v.Key,
+						VersionId: v.VersionId,
 					}
+					// Set BypassGovernanceRetention in separate step. Setting the value in the DeleteObjectInput may lead to the header being present with a value of false.
+					// This is not allowed by the S3 API and will result in a 409 error, if Object Locking is disabled.
+					if bypassGovernanceRetention {
+						input.SetBypassGovernanceRetention(true)
+					}
+
 					_, err := s3Client.DeleteObject(input)
 					if err != nil {
-						return true
+						fmt.Printf("Unable to remove delete marker %s in %s, retrying after 30 seconds: %s\n", *v.Key, bucket, err.Error())
+						return false
 					}
 				}
 				return true
 			})
+		if err != nil {
+			fmt.Printf("Unable to iterate bucket %s, retrying after 30 seconds: %s\n", bucket, err.Error())
+			time.Sleep(30 * time.Second)
+			continue
+		}
 
 		_, err = s3Client.DeleteBucket(&s3.DeleteBucketInput{
 			Bucket: aws.String(bucket),
 		})
 		if err != nil {
+			fmt.Printf("Unable to delete bucket %s, retrying after 30 seconds: %s\n", bucket, err.Error())
 			time.Sleep(30 * time.Second)
 			continue
 		}

--- a/build/versioning/main.go
+++ b/build/versioning/main.go
@@ -82,6 +82,7 @@ func cleanupBucket(bucket string, function string, args map[string]interface{}, 
 
 func main() {
 	endpoint := os.Getenv("SERVER_ENDPOINT")
+	region := os.Getenv("SERVER_REGION")
 	accessKey := os.Getenv("ACCESS_KEY")
 	secretKey := os.Getenv("SECRET_KEY")
 	secure := os.Getenv("ENABLE_HTTPS")
@@ -95,7 +96,7 @@ func main() {
 	s3Config := &aws.Config{
 		Credentials:      creds,
 		Endpoint:         aws.String(sdkEndpoint),
-		Region:           aws.String("us-east-1"),
+		Region:           aws.String(region),
 		S3ForcePathStyle: aws.Bool(true),
 	}
 

--- a/build/versioning/put.go
+++ b/build/versioning/put.go
@@ -54,7 +54,7 @@ func testPutObject() {
 		failureLog(function, args, startTime, "", "CreateBucket failed", err).Fatal()
 		return
 	}
-	defer cleanupBucket(bucket, function, args, startTime)
+	defer cleanupBucket(bucket, function, args, startTime, false)
 
 	putVersioningInput := &s3.PutBucketVersioningInput{
 		Bucket: aws.String(bucket),
@@ -165,7 +165,7 @@ func testPutObjectWithTaggingAndMetadata() {
 		failureLog(function, args, startTime, "", "CreateBucket failed", err).Fatal()
 		return
 	}
-	defer cleanupBucket(bucket, function, args, startTime)
+	defer cleanupBucket(bucket, function, args, startTime, false)
 
 	putVersioningInput := &s3.PutBucketVersioningInput{
 		Bucket: aws.String(bucket),

--- a/build/versioning/retention.go
+++ b/build/versioning/retention.go
@@ -54,7 +54,7 @@ func testLockingRetentionGovernance() {
 		failureLog(function, args, startTime, "", "CreateBucket failed", err).Fatal()
 		return
 	}
-	defer cleanupBucket(bucket, function, args, startTime)
+	defer cleanupBucket(bucket, function, args, startTime, true)
 
 	type uploadedObject struct {
 		retention        string
@@ -154,7 +154,7 @@ func testLockingRetentionCompliance() {
 		return
 	}
 
-	defer cleanupBucket(bucket, function, args, startTime)
+	defer cleanupBucket(bucket, function, args, startTime, true)
 
 	type uploadedObject struct {
 		retention        string
@@ -262,7 +262,7 @@ func testPutGetDeleteLockingRetention(function, retentionMode string) {
 		return
 	}
 
-	defer cleanupBucket(bucket, function, args, startTime)
+	defer cleanupBucket(bucket, function, args, startTime, true)
 
 	oneMinuteRetention := time.Now().UTC().Add(time.Minute)
 	twoMinutesRetention := oneMinuteRetention.Add(time.Minute)

--- a/build/versioning/stat.go
+++ b/build/versioning/stat.go
@@ -49,7 +49,7 @@ func testStatObject() {
 		failureLog(function, args, startTime, "", "CreateBucket failed", err).Fatal()
 		return
 	}
-	defer cleanupBucket(bucket, function, args, startTime)
+	defer cleanupBucket(bucket, function, args, startTime, false)
 
 	putVersioningInput := &s3.PutBucketVersioningInput{
 		Bucket: aws.String(bucket),

--- a/build/versioning/tagging.go
+++ b/build/versioning/tagging.go
@@ -50,7 +50,7 @@ func testTagging() {
 		failureLog(function, args, startTime, "", "CreateBucket failed", err).Fatal()
 		return
 	}
-	defer cleanupBucket(bucket, function, args, startTime)
+	defer cleanupBucket(bucket, function, args, startTime, false)
 
 	putVersioningInput := &s3.PutBucketVersioningInput{
 		Bucket: aws.String(bucket),

--- a/run/core/aws-sdk-ruby/aws-stub-tests.rb
+++ b/run/core/aws-sdk-ruby/aws-stub-tests.rb
@@ -728,8 +728,7 @@ class AwsSdkRubyTest
 
       # Generate presigned Put URL and parse it
       uri = URI.parse(presignedPutWrapper(bucket_name, file_name, log_output))
-      request = Net::HTTP::Put.new(uri.request_uri, 'content-type' => 'application/octet-stream',
-                                   'x-amz-acl' => 'public-read')
+      request = Net::HTTP::Put.new(uri.request_uri, 'content-type' => 'application/octet-stream')
       request.body = IO.read(File.join(data_dir, file_name))
 
       http = Net::HTTP.new(uri.host, uri.port)

--- a/run/core/awscli/test.sh
+++ b/run/core/awscli/test.sh
@@ -53,7 +53,7 @@ function log_alert() {
 function make_bucket() {
 	# Make bucket
 	bucket_name="awscli-mint-test-bucket-$RANDOM"
-	function="${AWS} s3api create-bucket --bucket ${bucket_name}"
+	function="${AWS} s3api create-bucket --bucket ${bucket_name} --create-bucket-configuration LocationConstraint=${SERVER_REGION}"
 
 	# execute the test
 	out=$($function 2>&1)


### PR DESCRIPTION
Hey everyone,
I tried using the tool based on main but encountered various errors. I went through them and tried to fix the ones that are relevant to us. 

Tbh, I am a bit confused by these errors as they are very surface level. Is the tool actively used inside the minio org?

Please also see the commit bodies as I included some info there.

**Proposed changes:**
- Respect `SERVER_REGION` env variable in `aws-sdk-go`, `aws-sdk-java` and `versioning` target
- Add locationconstraint flag that is necessary when using the AWS CLI
- [Remove](https://github.com/minio/mint/compare/master...derpsteb:mint:fix-region?expand=1#diff-5e4a9357903560b5a025289af636f18a810a4d4d4e322c4bf8846676f7690117R731) a header that caused API errors in `aws-sdk-ruby`. Please note that _I have no idea_ what this header might be used for. Removing it might silently break some expectations. However, in it's current form I don't think the request ever succeeded. 
- Fix bugs inside `versioning` target that caused API errors
- The code removed [here](https://github.com/minio/mint/compare/master...derpsteb:mint:fix-region?expand=1#diff-e7983266944a38f04f75e08371965600463bcd5d950d285eec4e19dd4f669e8aL269-L281) didn't make sense to me. Again, _I am uncertain_ what this might be currently used for. Especially after setting a correct value for `ObjectLockLegalHoldStatus` in line 263 

Please ping me if I should give more context to the changes.