### PR TITLE
Use separate counter for current running test no

### DIFF
--- a/mint.sh
+++ b/mint.sh
@@ -165,14 +165,16 @@ function main() {
 
 	count="${#run_list[@]}"
 	i=0
+	j=0
 	for sdk_dir in "${run_list[@]}"; do
 		sdk_name=$(basename "$sdk_dir")
 		((i++))
+		((j++))
 		if [ ! -d "$sdk_dir" ]; then
 			echo "Test $sdk_name not found. Exiting Mint."
 			exit 1
 		fi
-		echo -n "($i/$count) Running $sdk_name tests ... "
+		echo -n "($j/$count) Running $sdk_name tests ... "
 		if ! run_test "$sdk_dir"; then
 			((i--))
 		fi


### PR DESCRIPTION
If a test fails the counter gets decremented for currently running test as below

```
(1/15) Running aws-sdk-go tests ... FAILED in 2 minutes and 2 seconds
{
  "alert": "",
  "args": {
    "bucketName": "aws-sdk-go-test-1eajd2wam6amka",
    "expiry": 60000000000,
    "objectName": "presignedTest"
  },
  "duration": 121969,
  "error": "BucketAlreadyOwnedByYou: Your previous request to create the named bucket succeeded and you already own it.\n\tstatus code: 409, request id: 17DA1C8B8DB5BD18, host id: 4de9f6f45bfb3a31ea395f3d063545f58e6a1995d2b05dee6b579f19079a6455",
  "function": "PresignedPut",
  "message": "AWS SDK Go CreateBucket Failed",
  "name": "aws-sdk-go",
  "status": "FAIL"
}
(1/15) Running aws-sdk-java tests ... done in 1 seconds
(2/15) Running aws-sdk-java-v2 tests ... done in 2 seconds
(3/15) Running aws-sdk-php tests ... done in 41 seconds
....
```